### PR TITLE
Increase i maximum from 12 to 13

### DIFF
--- a/source/app/users.cpp
+++ b/source/app/users.cpp
@@ -10,7 +10,7 @@ bool loadUsers() {
     nn::act::SlotNo currentAccount = nn::act::GetSlotNo();
     nn::act::SlotNo defaultAccount = nn::act::GetDefaultAccount();
 
-    for (nn::act::SlotNo i=1; i<12; i++) {
+    for (nn::act::SlotNo i=1; i<13; i++) {
         if (nn::act::IsSlotOccupied(i) == true) {
             userAccount newAccount;
             


### PR DESCRIPTION
This pull requests increases the `i` maximum from 12 to 13, which allows Dumpling to locate the last user on the system.

I have tested this and confirmed it to work on my system; YMMV but hopefully not - [you can download the files here](https://github.com/jbmagination/dumpling/releases/tag/i-increase) or build it yourself