### PR TITLE
Dumpling Environment Support

### DIFF
--- a/source/app/cfw.cpp
+++ b/source/app/cfw.cpp
@@ -55,8 +55,13 @@ CFWVersion testCFW() {
             WHBLogFreetypeDraw();
             currCFWVersion = CFWVersion::DUMPLING;
         }
+        else if (mochaVersion == 999) {
+            WHBLogPrintf("Detected custom Mocha payload...");
+            WHBLogPrintf("Running in Dumpling environment, all devices allowed");
+            currCFWVersion = CFWVersion::CUSTOM_MOCHA;
+        }
         else {
-            uint8_t onlyAllowUSB = showDialogPrompt(L"Detected Mocha or Tiramisu CFW...\nYou can't use SD card access while using Aroma safely!\n\nTo enable SD card support, reboot your Wii U while holding the R button.\nThis'll boot your Wii U without Aroma.\nThen, use your web browser and go to https://dumplingapp.com to start Dumpling.\n\nYou can skip this step if you're only planning on dumping to USB sticks.", L"Continue and only show USB devices", L"Exit Dumpling (user needs to manually reboot Wii U)");
+            uint8_t onlyAllowUSB = showDialogPrompt(L"Detected Mocha or Tiramisu CFW...\nYou can't use SD card access while using Aroma safely!\n\nTo enable SD card support, reboot your Wii U while holding the R button.\nThis'll boot your Wii U without Aroma.\nThen, use your web browser and go to https://dumplingapp.com\nto start Dumpling.\n\nAlternatively, by holding X at boot, you can enter the Dumpling environment\nto enable SD Card access as well.\n\nYou can skip this step if you're only planning on dumping to USB sticks.", L"Continue and only show USB devices", L"Exit Dumpling (this will reboot your Wii U)");
             if (onlyAllowUSB == 0) {
                 WHBLogFreetypeClear();
                 WHBLogPrint("Detected Mocha or Tiramisu CFW...");
@@ -72,6 +77,8 @@ CFWVersion testCFW() {
                 WHBLogPrint("");
                 WHBLogPrint("After you reboot your Wii U while holding the R button");
                 WHBLogPrint("you need to use the web browser and go to https://dumplingapp.com");
+                WHBLogPrint("");
+                WHBLogPrint("Alternatively, you can open the Dumpling environment by holding X at boot");
                 WHBLogPrint("After doing this you can use Dumpling with full capabilities!");
                 WHBLogPrint("");
                 WHBLogPrint("Don't forget to memorize this link and button combination!");

--- a/source/app/cfw.h
+++ b/source/app/cfw.h
@@ -6,6 +6,7 @@ enum CFWVersion {
     FAILED,
     NONE,
     MOCHA_FSCLIENT,
+    CUSTOM_MOCHA,
     DUMPLING,
     CEMU,
 };

--- a/source/app/gui.cpp
+++ b/source/app/gui.cpp
@@ -52,7 +52,7 @@ bool stillRunning() {
     return true;
 }
 
-void exitApplication(bool shutdownOnExit) {
+void exitApplication(bool rebootOnExit) {
     // Loop through ProcUI messages until it says Dumpling should exit
     if (getCFWVersion() == MOCHA_FSCLIENT) {
         SYSLaunchMenu();
@@ -72,7 +72,7 @@ void exitApplication(bool shutdownOnExit) {
                 continue;
             }
 
-            if (shutdownOnExit) OSShutdown();
+            if (rebootOnExit) OSLaunchTitlel(OS_TITLE_ID_REBOOT, 0);
             else if (usingHBL) SYSRelaunchTitle(0, nullptr);
         }
     }

--- a/source/app/main.cpp
+++ b/source/app/main.cpp
@@ -27,7 +27,7 @@ int main() {
 
     // Start Dumpling
     showLoadingScreen();
-    if (testCFW() != FAILED && ((getCFWVersion() == MOCHA_FSCLIENT || getCFWVersion() == CEMU) || executeExploit()) && initCFW() && mountSystemDrives() && loadUsers() && loadTitles(true)) {
+    if (testCFW() != FAILED && ((getCFWVersion() == MOCHA_FSCLIENT || getCFWVersion() == CEMU || getCFWVersion() == CUSTOM_MOCHA) || executeExploit()) && initCFW() && mountSystemDrives() && loadUsers() && loadTitles(true)) {
         WHBLogFreetypePrint(L"");
         WHBLogPrint("Finished loading!");
         WHBLogFreetypeDraw();
@@ -36,7 +36,7 @@ int main() {
     }
 
     WHBLogPrint("");
-    WHBLogPrint(getCFWVersion() == MOCHA_FSCLIENT ? "Exiting Dumpling..." : "Exiting Dumpling and shutting off Wii U...");
+    WHBLogPrint(getCFWVersion() == MOCHA_FSCLIENT ? "Exiting Dumpling..." : "Exiting Dumpling and rebooting Wii U...");
     WHBLogFreetypeDraw();
     sleep_for(5s);
 

--- a/source/app/menu.cpp
+++ b/source/app/menu.cpp
@@ -69,7 +69,7 @@ void showMainMenu() {
                 break;
             }
             if (pressedBack()) {
-                uint8_t exitSelectedOption = showDialogPrompt(getCFWVersion() == MOCHA_FSCLIENT ? L"Do you really want to exit Dumpling?" : L"Do you really want to exit Dumpling?\nYour console will shutdown to prevent compatibility issues!", L"Yes", L"No");
+                uint8_t exitSelectedOption = showDialogPrompt(getCFWVersion() == MOCHA_FSCLIENT ? L"Do you really want to exit Dumpling?" : L"Do you really want to exit Dumpling?\nYour console will reboot to prevent compatibility issues!", L"Yes", L"No");
                 if (exitSelectedOption == 0) {
                     WHBLogFreetypeClear();
                     return;


### PR DESCRIPTION
Allows a Dumpling environment to be loaded via the Environment Loader. In this environment, Dumpling is able to have complete SD Card access.

Environment requires these forks of the [MochaPayload](https://github.com/Fangal-Airbag/MochaPayload) and [LaunchInstaller](https://github.com/Fangal-Airbag/LaunchInstaller) setup modules.

Additionally added support for rebooting the Wii U instead of shutting it down when Dumpling exits.